### PR TITLE
Implement Activity Planner selection with Driver view

### DIFF
--- a/code/web/src/App.test.js
+++ b/code/web/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/welcome to familyapp/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/code/web/src/components/ActivityPlanner/ActivityPlanner.js
+++ b/code/web/src/components/ActivityPlanner/ActivityPlanner.js
@@ -1,9 +1,67 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 function ActivityPlanner() {
+    const [activity, setActivity] = useState("");
+    const [date, setDate] = useState("");
+    const [time, setTime] = useState("");
+    const [activities, setActivities] = useState([]);
+
+    useEffect(() => {
+        const saved = localStorage.getItem('activities');
+        if (saved) {
+            try {
+                setActivities(JSON.parse(saved));
+            } catch (e) {
+                console.error('Failed to parse saved activities');
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        localStorage.setItem('activities', JSON.stringify(activities));
+    }, [activities]);
+
+    const addActivity = (e) => {
+        e.preventDefault();
+        if (!activity || !date || !time) return;
+        setActivities([...activities, { activity, date, time }]);
+        setActivity("");
+        setDate("");
+        setTime("");
+    };
+
     return (
         <div>
             <h2>Activity Planner</h2>
+            <form onSubmit={addActivity} style={{ marginBottom: '20px' }}>
+                <input
+                    type="text"
+                    placeholder="Activity"
+                    value={activity}
+                    onChange={(e) => setActivity(e.target.value)}
+                    style={{ marginRight: '10px' }}
+                />
+                <input
+                    type="date"
+                    value={date}
+                    onChange={(e) => setDate(e.target.value)}
+                    style={{ marginRight: '10px' }}
+                />
+                <input
+                    type="time"
+                    value={time}
+                    onChange={(e) => setTime(e.target.value)}
+                    style={{ marginRight: '10px' }}
+                />
+                <button type="submit">Add</button>
+            </form>
+            {activities.length > 0 && (
+                <ul>
+                    {activities.map((a, idx) => (
+                        <li key={idx}>{`${a.activity} - ${a.date} ${a.time}`}</li>
+                    ))}
+                </ul>
+            )}
         </div>
     );
 }

--- a/code/web/src/pages/DriverDashboard.js
+++ b/code/web/src/pages/DriverDashboard.js
@@ -1,11 +1,32 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 function DriverDashboard() {
+  const [activities, setActivities] = useState([]);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('activities');
+    if (saved) {
+      try {
+        setActivities(JSON.parse(saved));
+      } catch (e) {
+        console.error('Failed to parse saved activities');
+      }
+    }
+  }, []);
+
   return (
     <div style={{ padding: '20px' }}>
       <h2>Driver Dashboard</h2>
       <p>View child pickup/drop schedule here.</p>
-      {/* Will connect to ActivityPlanner component in read-only mode */}
+      {activities.length > 0 ? (
+        <ul>
+          {activities.map((a, idx) => (
+            <li key={idx}>{`${a.activity} - ${a.date} ${a.time}`}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>No activities scheduled.</p>
+      )}
     </div>
   );
 }

--- a/code/web/src/setupTests.js
+++ b/code/web/src/setupTests.js
@@ -3,3 +3,19 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill window.matchMedia for components relying on it (e.g., react-slick)
+if (!window.matchMedia) {
+  window.matchMedia = function(query) {
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add ability for parents to plan activities with a date and time
- persist activities in localStorage
- show read-only activities on Driver dashboard
- update tests and polyfills for `matchMedia`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845aee514f4832ab6f1a4c909f00171